### PR TITLE
Upgrade .NET to 10 and treat warnings as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
 
       - name: Build
         run: dotnet build dotnet/PersonalSite.sln

--- a/dotnet/PersonalSite.AwsLambda/PersonalSite.AwsLambda.csproj
+++ b/dotnet/PersonalSite.AwsLambda/PersonalSite.AwsLambda.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <!-- CS8669: generated code from Amazon.Lambda.Annotations lacks #nullable directive -->
+        <NoWarn>CS8669</NoWarn>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <AWSProjectType>Lambda</AWSProjectType>
         <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->

--- a/dotnet/PersonalSite.AwsLambda/serverless.template
+++ b/dotnet/PersonalSite.AwsLambda/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v1.3.0.0).",
+  "Description": "An AWS Serverless Application. This template is partially managed by Amazon.Lambda.Annotations (v1.9.0.0).",
   "Resources": {
     "PersonalSiteAwsLambdaFunctionsGetContentGenerated": {
       "Type": "AWS::Serverless::Function",
@@ -9,10 +9,16 @@
         "Tool": "Amazon.Lambda.Annotations",
         "SyncedEvents": [
           "RootGet"
-        ]
+        ],
+        "SyncedEventProperties": {
+          "RootGet": [
+            "Path",
+            "Method"
+          ]
+        }
       },
       "Properties": {
-        "Runtime": "dotnet8",
+        "Runtime": "dotnet10",
         "CodeUri": ".",
         "MemorySize": 512,
         "Timeout": 30,

--- a/dotnet/PersonalSite.ContentModel/PersonalSite.ContentModel.csproj
+++ b/dotnet/PersonalSite.ContentModel/PersonalSite.ContentModel.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- Override vulnerable transitive dependency from contentful.codefirst -->
+      <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.0" />
       <PackageReference Include="contentful.aspnetcore" Version="7.7.0" />
       <PackageReference Include="contentful.codefirst" Version="0.2.2" />
       <PackageReference Include="Markdig.Signed" Version="0.45.0" />

--- a/dotnet/PersonalSite.Utilities/PersonalSite.Utilities.csproj
+++ b/dotnet/PersonalSite.Utilities/PersonalSite.Utilities.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/dotnet/PersonalSite.Web/Extensions/RequestExtensions.cs
+++ b/dotnet/PersonalSite.Web/Extensions/RequestExtensions.cs
@@ -17,6 +17,6 @@ public static class RequestExtensions
     
     public static string GetDomain(this HttpRequest request)
     {
-        return request.Host.Value.Split(':')[0].ToLower();
+        return (request.Host.Value ?? string.Empty).Split(':')[0].ToLower();
     }
 }

--- a/dotnet/PersonalSite.Web/PersonalSite.Web.csproj
+++ b/dotnet/PersonalSite.Web/PersonalSite.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <LangVersion>12</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.418",
+    "version": "10.0.103",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/dotnet/test/PersonalSite.AwsLambda.Tests/PersonalSite.AwsLambda.Tests.csproj
+++ b/dotnet/test/PersonalSite.AwsLambda.Tests/PersonalSite.AwsLambda.Tests.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Upgrades all projects from `net8.0` to `net10.0` (SDK `10.0.103`)
- Adds `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` to all projects
- Removes explicit `<LangVersion>12</LangVersion>` (defaults to C# 14 with .NET 10)
- Overrides vulnerable transitive dep `System.Security.Cryptography.Xml` 4.5.0 (from `contentful.codefirst`) with 9.0.0
- Fixes `HostString.Value` null dereference in `RequestExtensions.cs` (now `string?` in .NET 10)
- Updates Lambda runtime to `dotnet10` in `serverless.template`
- Updates CI workflow to `dotnet-version: 10.x`

## Test plan

- [x] CI build passes on the PR
- [x] `dotnet build` succeeds with 0 warnings and 0 errors locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)