### PR TITLE
Update Dockerfile to .NET 10 and add Dockerfile renovate manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,13 @@
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "Dockerfile dependencies",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "automergeType": "pr"
     }
   ],
   "labels": [

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,11 +1,11 @@
-﻿FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+﻿FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /app
 COPY . ./
 WORKDIR ./PersonalSite.Web
 RUN dotnet restore
 RUN dotnet publish -c release -o /app/out
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 ENV ASPNETCORE_ENVIRONMENT=local
 EXPOSE 80
 #EXPOSE 443


### PR DESCRIPTION
## Summary
- Updates `dotnet/Dockerfile` base images from `8.0` to `10.0` (`sdk` and `aspnet`) to match the recent .NET 10 upgrade
- Adds a `dockerfile` manager rule to `renovate.json` so future Dockerfile image updates are tracked and auto-merged

## Test plan
- [ ] Verify Docker build succeeds with .NET 10 base images
- [ ] Confirm Renovate picks up Dockerfile dependencies on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)